### PR TITLE
Port of nRF52833

### DIFF
--- a/arch/cpu/nrf52840/Makefile.nrf52840
+++ b/arch/cpu/nrf52840/Makefile.nrf52840
@@ -26,8 +26,13 @@ ifeq ($(BOARD), dongle)
   NRF52840_NATIVE_USB ?= 1
   NRF52840_USB_DFU_TRIGGER ?= 1
 else
-  LDSCRIPT ?= $(CONTIKI_CPU)/ld/nrf52840.ld
-  CFLAGS += -DBOARD_PCA10056
+  ifeq ($(BOARD), 33dk)
+    LDSCRIPT ?= $(CONTIKI_CPU)/ld/nrf52833.ld
+    CFLAGS += -DBOARD_PCA10100
+  else
+    LDSCRIPT ?= $(CONTIKI_CPU)/ld/nrf52840.ld
+    CFLAGS += -DBOARD_PCA10056
+  endif
   NRF52840_NATIVE_USB ?= 0
   ifeq ($(NRF52840_NATIVE_USB)$(NRF52840_USB_DFU_TRIGGER), 11)
     $(warning "Building for BOARD=dk")
@@ -47,7 +52,11 @@ CONTIKI_CPU_SOURCEFILES += nrf52840-ieee.c
 
 CONTIKI_SOURCEFILES += $(CONTIKI_CPU_SOURCEFILES)
 
-CFLAGS += -DNRF52840_XXAA
+ifeq ($(BOARD), 33dk)
+  CFLAGS += -DNRF52833_XXAA
+else
+  CFLAGS += -DNRF52840_XXAA
+endif
 CFLAGS += -D__HEAP_SIZE=512
 CFLAGS += -DSWI_DISABLE0
 CFLAGS += -DCONFIG_GPIO_AS_PINRESET
@@ -73,12 +82,17 @@ NRF52_SDK_C_SRCS += components/boards/boards.c \
   modules/nrfx/drivers/src/nrfx_rng.c \
   modules/nrfx/drivers/src/nrfx_wdt.c \
   modules/nrfx/drivers/src/nrfx_power.c \
-  modules/nrfx/mdk/system_nrf52840.c \
   integration/nrfx/legacy/nrf_drv_clock.c \
   integration/nrfx/legacy/nrf_drv_rng.c \
   integration/nrfx/legacy/nrf_drv_power.c \
   integration/nrfx/legacy/nrf_drv_twi.c \
   modules/nrfx/drivers/src/nrfx_twi.c \
+
+ifeq ($(BOARD), 33dk)
+  NRF52_SDK_C_SRCS += modules/nrfx/mdk/system_nrf52833.c
+else
+  NRF52_SDK_C_SRCS += modules/nrfx/mdk/system_nrf52840.c
+endif
 
 #  components/libraries/usbd/app_usbd.c \
 #  components/libraries/usbd/class/cdc/acm/app_usbd_cdc_acm.c \
@@ -86,7 +100,11 @@ NRF52_SDK_C_SRCS += components/boards/boards.c \
 #  components/libraries/usbd/app_usbd_serial_num.c \
 #  components/libraries/usbd/app_usbd_string_desc.c \
 
-NRF52_SDK_ASM_SRCS = modules/nrfx/mdk/gcc_startup_nrf52840.S
+ifeq ($(BOARD), 33dk)
+  NRF52_SDK_ASM_SRCS = modules/nrfx/mdk/gcc_startup_nrf52833.S
+else
+  NRF52_SDK_ASM_SRCS = modules/nrfx/mdk/gcc_startup_nrf52840.S
+endif
 
 CONTIKI_SOURCEFILES += $(notdir $(NRF52_SDK_C_SRCS))
 CONTIKI_SOURCEFILES += $(notdir $(NRF52_SDK_ASM_SRCS))

--- a/arch/cpu/nrf52840/ld/nrf52833.ld
+++ b/arch/cpu/nrf52840/ld/nrf52833.ld
@@ -1,0 +1,18 @@
+/* Linker script to configure memory regions. */
+
+SEARCH_DIR(.)
+GROUP(-lgcc -lc -lnosys)
+
+MEMORY
+{
+  FLASH (rx) : ORIGIN = 0x00000000, LENGTH = 0x80000
+  RAM (rwx) :  ORIGIN = 0x20000000, LENGTH = 0x20000
+}
+
+INCLUDE "nrf_common.ld"
+
+/* These symbols are used by the stack check library. */
+_stack = end;
+_stack_origin = ORIGIN(RAM) + LENGTH(RAM);
+_heap = _stack;
+_eheap = _stack_origin;

--- a/arch/platform/nrf52840/33dk/Makefile.33dk
+++ b/arch/platform/nrf52840/33dk/Makefile.33dk
@@ -1,0 +1,2 @@
+CONTIKI_TARGET_DIRS += dk
+CONTIKI_TARGET_SOURCEFILES += board-leds.c board-buttons.c nrf52840dk-sensors.c

--- a/arch/platform/nrf52840/33dk/board-buttons.c
+++ b/arch/platform/nrf52840/33dk/board-buttons.c
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2020, George Oikonomou - https://spd.gr
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+/*---------------------------------------------------------------------------*/
+/**
+ * \addtogroup nrf52833dk-devices Device drivers
+ * @{
+ *
+ * \addtogroup nrf52833dk-devices-button Buttons driver
+ * @{
+ */
+/*---------------------------------------------------------------------------*/
+#include "contiki.h"
+#include "boards.h"
+#include "dev/button-hal.h"
+/*---------------------------------------------------------------------------*/
+BUTTON_HAL_BUTTON(btn_1, "Button 1", 0, BUTTON_1, \
+                  GPIO_HAL_PIN_CFG_PULL_UP, BUTTON_HAL_ID_BUTTON_ZERO, true);
+BUTTON_HAL_BUTTON(btn_2, "Button 2", 0, BUTTON_2, \
+                  GPIO_HAL_PIN_CFG_PULL_UP, BUTTON_HAL_ID_BUTTON_ONE, true);
+BUTTON_HAL_BUTTON(btn_3, "Button 3", 0, BUTTON_3, \
+                  GPIO_HAL_PIN_CFG_PULL_UP, BUTTON_HAL_ID_BUTTON_TWO, true);
+BUTTON_HAL_BUTTON(btn_4, "Button 4", 0, BUTTON_4, \
+                  GPIO_HAL_PIN_CFG_PULL_UP, BUTTON_HAL_ID_BUTTON_THREE, true);
+/*---------------------------------------------------------------------------*/
+BUTTON_HAL_BUTTONS(&btn_1, &btn_2, &btn_3, &btn_4);
+/*---------------------------------------------------------------------------*/
+/**
+ * @}
+ * @}
+ */

--- a/arch/platform/nrf52840/33dk/board-leds.c
+++ b/arch/platform/nrf52840/33dk/board-leds.c
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2020, George Oikonomou - https://spd.gr
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+/*---------------------------------------------------------------------------*/
+/**
+ * \addtogroup nrf52840dk
+ * @{
+ *
+ * \addtogroup nrf52840dk-devices Device drivers
+ * @{
+ *
+ * \addtogroup nrf52840dk-devices-led LED driver
+ * @{
+ */
+/*---------------------------------------------------------------------------*/
+#include "contiki.h"
+#include "boards.h"
+#include "dev/leds.h"
+#include "dev/gpio-hal.h"
+#include "dev/gpio-hal-arch.h"
+
+#include <stdbool.h>
+/*---------------------------------------------------------------------------*/
+const leds_t leds_arch_leds[] = {
+  {
+    .port = 0,
+    .pin = BSP_LED_0,
+    .negative_logic = true
+  },
+  {
+    .port = 0,
+    .pin = BSP_LED_1,
+    .negative_logic = true
+  },
+  {
+    .port = 0,
+    .pin = BSP_LED_2,
+    .negative_logic = true
+  },
+  {
+    .port = 0,
+    .pin = BSP_LED_3,
+    .negative_logic = true
+  },
+};
+/*---------------------------------------------------------------------------*/
+/**
+ * @}
+ * @}
+ * @}
+ */

--- a/arch/platform/nrf52840/33dk/nrf52833dk-sensors.c
+++ b/arch/platform/nrf52840/33dk/nrf52833dk-sensors.c
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2015, Nordic Semiconductor
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the Institute nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE INSTITUTE AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ */
+
+/**
+ * \addtogroup nrf52840dk
+ * @{
+ *
+ * \addtogroup nrf52840dk-devices Device drivers
+ * @{
+ *
+ * \addtogroup nrf52840dk-sensors Sensors
+ *  The nRF52 DK exports 4 button sensors and an internal temperature sensor.
+ * @{
+ *
+ * \file
+ *         This file exports a global sensors table.
+ * \author
+ *         Wojciech Bober <wojciech.bober@nordicsemi.no>
+ */
+/*---------------------------------------------------------------------------*/
+#include <string.h>
+#include "contiki.h"
+#include "lib/sensors.h"
+#include "button-sensor.h"
+#include "common/temperature-sensor.h"
+/*---------------------------------------------------------------------------*/
+SENSORS(&temperature_sensor);
+/*---------------------------------------------------------------------------*/
+/**
+ * @}
+ * @}
+ * @}
+ */

--- a/arch/platform/nrf52840/33dk/nrf52840-board-def.h
+++ b/arch/platform/nrf52840/33dk/nrf52840-board-def.h
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2015, Nordic Semiconductor
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the Institute nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE INSTITUTE AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ */
+
+/**
+ * \addtogroup platform
+ * @{
+ *
+ * \addtogroup nrf52833dk nRF52840 Development Kit
+ * @{
+ *
+ * \addtogroup nrf52833dk-platform-conf Platform configuration
+ * @{
+ * \file
+ *         Platform features configuration.
+ * \author
+ *         Wojciech Bober <wojciech.bober@nordicsemi.no>
+ *
+ */
+#ifndef NRF52840_BOARD_DEF_H_
+#define NRF52840_BOARD_DEF_H_
+
+#include "boards.h"
+
+#define PLATFORM_HAS_BATTERY                    0
+#define PLATFORM_HAS_RADIO                      0
+#define PLATFORM_HAS_TEMPERATURE                1
+
+/**
+ * \name Leds configurations
+ *
+ * On nRF52dk all leds are green.
+ *
+ * @{
+ */
+#define PLATFORM_HAS_LEDS                       1
+#define LEDS_CONF_COUNT                         4
+
+#define LEDS_CONF_GREEN     1
+/** @} */
+/**
+ * \name Button configurations
+ *
+ * @{
+ */
+/* Notify various examples that we have Buttons */
+#define PLATFORM_HAS_BUTTON      1
+#define PLATFORM_SUPPORTS_BUTTON_HAL 1
+
+/**
+ * \brief nRF52 RTC instance to be used for Contiki clock driver.
+ */
+#define PLATFORM_RTC_INSTANCE_ID     0
+
+/**
+ * \brief nRF52 timer instance to be used for Contiki rtimer driver.
+ */
+#define PLATFORM_TIMER_INSTANCE_ID   0
+
+/** @} */
+
+/**
+ * \name UART0 Pin configurations
+ *
+ * @{
+ */
+
+#define NRF_UART0_TX_PIN 6
+#define NRF_UART0_RX_PIN 8
+
+/** @} */
+/*---------------------------------------------------------------------------*/
+/** @}
+ *  @}
+ *  @}
+ */
+#endif /* NRF52840_BOARD_DEF_H_ */

--- a/arch/platform/nrf52840/Makefile.nrf52840
+++ b/arch/platform/nrf52840/Makefile.nrf52840
@@ -4,7 +4,7 @@ endif
 
 ### Board selection
 BOARD ?= dk
-BOARDS = dk dongle
+BOARDS = dk 33dk dongle
 
 ### Unless the example dictates otherwise, build with code size optimisations switched off
 SMALL ?= 0

--- a/arch/platform/nrf52840/doxygen-group.txt
+++ b/arch/platform/nrf52840/doxygen-group.txt
@@ -3,6 +3,10 @@
  * \ingroup nrf52840-platforms
  */
 /**
+ * \defgroup nrf52833dk nRF52833 Development Kit
+ * \ingroup nrf52840-platforms
+ */
+/**
  * \defgroup nrf52840dongle nRF52840 Dongle
  * \ingroup nrf52840-platforms
  */

--- a/os/net/mac/osf/nrf52840-osf.c
+++ b/os/net/mac/osf/nrf52840-osf.c
@@ -881,7 +881,7 @@ print_radio_config()
   LOG_DBG("NRF_CLOCK->LFCLKSRC     : 0x%08lX\n", NRF_CLOCK->LFCLKSRC);
   LOG_DBG("NRF_CLOCK->LFCLKSTAT    : 0x%08lX\n", NRF_CLOCK->LFCLKSTAT);
   LOG_DBG("NRF_CLOCK->HFCLKSTAT    : 0x%08lX\n", NRF_CLOCK->HFCLKSTAT);
-  LOG_DBG("NRF_CLOCK->LFRCMODE     : 0x%08lX\n", NRF_CLOCK->LFRCMODE);
+  // LOG_DBG("NRF_CLOCK->LFRCMODE     : 0x%08lX\n", NRF_CLOCK->LFRCMODE);  // nrf52833 Port: commented out to avoid compile error, not needed
 
   LOG_DBG("NRF_WDT->RUNSTATUS      : 0x%08lX\n", NRF_WDT->RUNSTATUS);
   LOG_DBG("NRF_WDT->CRV            : 0x%08lX\n", NRF_WDT->CRV);


### PR DESCRIPTION
Initial port of the nRF52833 based on Fikret Basic's PR. LEDs currently not working.